### PR TITLE
Also check element.sticky in onScrollEvents

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -220,7 +220,7 @@ class Sticky {
    * @param {node} element - Element for which event function is fired
    */
    onScrollEvents(element) {
-    if (element.sticky.active) {
+    if (element.sticky && element.sticky.active) {
       this.setPosition(element);
     }
    }


### PR DESCRIPTION
There is a possibility the sticky is destroyed while the scroll event is active. This could cause a "Cannot read property 'active' of undefined"