### PR TITLE
[fix] sticky class top

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -260,6 +260,9 @@ class Sticky {
         left: element.sticky.rect.left + 'px',
         width: element.sticky.rect.width + 'px',
       });
+      if (element.sticky.stickyClass) {
+        element.classList.add(element.sticky.stickyClass);
+      }
     } else if (this.scrollTop > (element.sticky.rect.top - element.sticky.marginTop)) {
       this.css(element, {
         position: 'fixed',


### PR DESCRIPTION
the condition in `setPosition` that becomes active if the element is initially at top didn't take care of setting the sticky class

this PR fixes https://github.com/rgalus/sticky-js/issues/72