### PR TITLE
[feature] custom wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ data-margin-top | number | 0 | Margin between page and sticky element when scrol
 data-sticky-for | number | 0 | Breakpoint which when is bigger than viewport width, sticky is activated and when is smaller, then sticky is destroyed
 data-sticky-class | string | null | Class added to sticky element when it is stuck
 
+## Wrapper
+
+When setting the `wrap` option to `true`, the sticky element is wrapped in a `<span></span>` by default. If you need more control over the wrapper you can wrap the element yourself and just need to add `data-sticky-wrapper` to the wrapper so it gets recognized.
+
+```html
+<div data-sticky-wrapper>
+  <div class="sticky">
+    sticky element with a custom wrapper
+  </div>
+</div>
+```
+
 ### Development
 
 Clone this repository and run

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -91,7 +91,7 @@ class Sticky {
       element.onload = () => element.sticky.rect = this.getRectangle(element);
     }
 
-    if (element.sticky.wrap) {
+    if (element.sticky.wrap && element.parentNode.getAttribute('data-sticky-wrapper') === null) {
       this.wrapElement(element);
     }
 


### PR DESCRIPTION
the `wrap` option is quite limited because it always creates a `<span>` and (more important for me) it does change the DOM what results in loosing assigned event listeners on the element (before initializing sticky-js)

this PR implements support of a custom wrapper that gets used by the plugin if present (instead of wrapping the element itself)

I've added an example in the README.md