### PR TITLE
[perf] scrolling

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -192,7 +192,7 @@ class Sticky {
       element.sticky.active = false;
     }
 
-    this.setPosition(element);
+    this.setPosition(element, false);
    }
 
 
@@ -234,8 +234,8 @@ class Sticky {
    * @function
    * @param {node} element - Element that will be positioned if it's active
    */
-   setPosition(element) {
-    this.css(element, { position: '', width: '', top: '', left: '' });
+   setPosition(element, useAnimationFrame) {
+    this.css(element, { position: '', width: '', top: '', left: '' }, useAnimationFrame);
 
     if ((this.vp.height < element.sticky.rect.height) || !element.sticky.active) {
       return;
@@ -250,7 +250,7 @@ class Sticky {
         display: 'block',
         width: element.sticky.rect.width + 'px',
         height: element.sticky.rect.height + 'px',
-      });
+      }, useAnimationFrame);
     }
 
     if (
@@ -262,7 +262,7 @@ class Sticky {
         top: element.sticky.rect.top + 'px',
         left: element.sticky.rect.left + 'px',
         width: element.sticky.rect.width + 'px',
-      });
+      }, useAnimationFrame);
       if (element.sticky.stickyClass) {
         element.classList.add(element.sticky.stickyClass);
       }
@@ -271,7 +271,7 @@ class Sticky {
         position: 'fixed',
         width: element.sticky.rect.width + 'px',
         left: element.sticky.rect.left + 'px',
-      });
+      }, useAnimationFrame);
 
       if (
         (this.scrollTop + element.sticky.rect.height + element.sticky.marginTop)
@@ -283,24 +283,24 @@ class Sticky {
         }
 
         this.css(element, {
-          top: (element.sticky.container.rect.top + element.sticky.container.offsetHeight) - (this.scrollTop + element.sticky.rect.height + element.sticky.marginBottom) + 'px' }
-        );
+          top: (element.sticky.container.rect.top + element.sticky.container.offsetHeight) - (this.scrollTop + element.sticky.rect.height + element.sticky.marginBottom) + 'px'
+        }, useAnimationFrame);
       } else {
         if (element.sticky.stickyClass) {
           element.classList.add(element.sticky.stickyClass);
         }
 
-        this.css(element, { top: element.sticky.marginTop + 'px' });
+        this.css(element, { top: element.sticky.marginTop + 'px' }, useAnimationFrame);
       }
     } else {
       if (element.sticky.stickyClass) {
         element.classList.remove(element.sticky.stickyClass);
       }
 
-      this.css(element, { position: '', width: '', top: '', left: '' });
+      this.css(element, { position: '', width: '', top: '', left: '' }, useAnimationFrame);
 
       if (element.sticky.wrap) {
-        this.css(element.parentNode, { display: '', width: '', height: '' });
+        this.css(element.parentNode, { display: '', width: '', height: '' }, useAnimationFrame);
       }
     }
    }

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -175,8 +175,8 @@ class Sticky {
    onResizeEvents(element) {
     this.vp = this.getViewportSize();
 
-    element.sticky.rect = this.getRectangle(element);
-    element.sticky.container.rect = this.getRectangle(element.sticky.container);
+    element.sticky.rect = this.getRectangle(element, false);
+    element.sticky.container.rect = this.getRectangle(element.sticky.container, false);
 
     if (
       ((element.sticky.rect.top + element.sticky.rect.height) < (element.sticky.container.rect.top + element.sticky.container.rect.height))
@@ -364,8 +364,8 @@ class Sticky {
    * @param {node} element - Element which position & rectangle are returned
    * @return {object}
    */
-  getRectangle(element) {
-    this.css(element, { position: '', width: '', top: '', left: '' });
+  getRectangle(element, useAnimationFrame) {
+    this.css(element, { position: '', width: '', top: '', left: '' }, useAnimationFrame);
 
     const width = Math.max(element.offsetWidth, element.clientWidth, element.scrollWidth);
     const height = Math.max(element.offsetHeight, element.clientHeight, element.scrollHeight);
@@ -424,11 +424,23 @@ class Sticky {
    * @helper
    * @param {node} element - DOM element
    * @param {object} properties - CSS properties that will be added/removed from specified element
+   * @param {boolean} useAnimationFrame - if true requestAnimationFrame is used
    */
-  css(element, properties) {
-    for (let property in properties) {
-      if (properties.hasOwnProperty(property)) {
-        element.style[property] = properties[property];
+  css(element, properties, useAnimationFrame) {
+
+    if (useAnimationFrame !== false) {
+      window.requestAnimationFrame(function() {
+        for (let property in properties) {
+          if (properties.hasOwnProperty(property)) {
+            element.style[property] = properties[property];
+          }
+        }
+      });
+    } else {
+      for (let property in properties) {
+        if (properties.hasOwnProperty(property)) {
+          element.style[property] = properties[property];
+        }
       }
     }
   }

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -293,7 +293,7 @@ class Sticky {
 
         this.css(element, {
           top: (element.sticky.container.rect.top + element.sticky.container.offsetHeight) - (this.scrollTop + element.sticky.rect.height + element.sticky.marginBottom) + 'px'
-        }, useAnimationFrame);
+        });
       } else {
         if (element.sticky.stickyClass) {
           element.classList.add(element.sticky.stickyClass);


### PR DESCRIPTION
I was facing major performance issues in Safari resulting in jumping on quick scrolling.
The more content I've had in my sticky container the worse it was.

This PR improves the scrolling performance by using requestAnimationFrame what fixes my the Safari issue.

I've taken over the code from https://github.com/rgalus/sticky-js/pull/68 (hope you don't mind @Kukiwon) and polished it a bit.

Also fixes https://github.com/rgalus/sticky-js/issues/43

